### PR TITLE
Urgent banner tweaks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
-# To launch locally and override base URL:
+# To launch locally and display draft documents
 #
-#   hugo server server -D -b http://localhost:1313/
+#   hugo server -D
 #
 baseurl = "https://www.pdxpythonpirates.org"
 title = "Portland Python Pirates"
@@ -13,7 +13,12 @@ summaryLength = 40
 theme = "jeffprod"
 
 [params]
+    # this toggles display of the urgent banner text at the top of all pages
+    # individual pages can disable this with the page front matter 'display_urgent: false'
     display_urgent = true
+    # this overrides the header image for all pages;  comment out to disable
+    urgent_header_image = "/img/urgent-edx.jpg"
+
     urgent_link = "/edx"
     urgent_link_title = "Urgent: edX Policy Change"
     urgent_date = "2018-12-13"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,4 +1,6 @@
 {{ define "main" }}
+{{ partial "urgent-banner.html" . }}
+
 {{ $paginator := .Paginate (where .Site.RegularPages "Section" "post").ByPublishDate.Reverse }}
 
 <div class="columns">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,8 +47,11 @@
     <!-- hero -->
     <section class="hero is-info is-medium">
         {{ $bgimg := .Page.Params.header_image | default .Site.Params.header_image }}
-        {{/* swap out $bgimg for edx urgent message */}}
-        <div class="hero-body" style="background-image: url({{ "/img/urgent-edx.jpg" }});">
+        {{ if isset .Site.Params "urgent_header_image" }}
+            {{/* override bg image if urgent image path is set */}}
+            {{ $bgimg = .Site.Params.urgent_header_image }}
+        {{ end }}
+        <div class="hero-body" style="background-image: url({{ $bgimg | absURL }});">
             <div class="container has-text-centered">
                 <br>
                 <h1 class="title is-size-1">

--- a/layouts/partials/urgent-banner.html
+++ b/layouts/partials/urgent-banner.html
@@ -1,5 +1,4 @@
-{{ if .Site.Params.display_urgent | default false}}
-{{ if .Page.Params.display_urgent | default true }}
+{{ if and (.Site.Params.display_urgent | default false) (.Page.Params.display_urgent | default true) }}
 <div class="columns">
     <div class="column is-12">
         <div class="tile is-child box danger">
@@ -18,5 +17,4 @@
         </div>
     </div>
 </div>
-{{ end }}
 {{ end }}


### PR DESCRIPTION
- added urgent banner to list pages (e.g. /post)
- urgent_header_image value now toggles display