### PR TITLE
Rolling back changes after edX firedrill

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,9 +15,9 @@ theme = "jeffprod"
 [params]
     # this toggles display of the urgent banner text at the top of all pages
     # individual pages can disable this with the page front matter 'display_urgent: false'
-    display_urgent = true
+#    display_urgent = true
     # this overrides the header image for all pages;  comment out to disable
-    urgent_header_image = "/img/urgent-edx.jpg"
+#    urgent_header_image = "/img/urgent-edx.jpg"
 
     urgent_link = "/edx"
     urgent_link_title = "Urgent: edX Policy Change"

--- a/content/edx.md
+++ b/content/edx.md
@@ -6,6 +6,8 @@ tags: ["edx"]
 pinned: true
 weight: 5
 display_urgent: false
+# marked draft to remove from site, but keep as example
+draft: true
 ---
 
 # Urgent: edX Policy Change

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,7 +21,6 @@
                 <img src="{{ "img/jolly-roger.png" | absURL }}">
             </a>
             <a class="navbar-item" href="{{ .Site.BaseURL | absURL }}">Home</a>
-            <a class="navbar-item" href="{{ "/edx" | absURL }}">edX Update</a>
         
             <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                 <span aria-hidden="true"></span>


### PR DESCRIPTION
This reverts the site back to standard messaging minus urgent banner and images.

Merge this Monday after the edX deadline passes.