### PR TITLE
Make urgent nav link configurable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,10 @@ theme = "jeffprod"
     # this overrides the header image for all pages;  comment out to disable
     urgent_header_image = "/img/urgent-edx.jpg"
 
-    urgent_link = "/edx"
+    urgent_url = "/edx"
+    # text displayed in top page nav; unset this to remove
+    urgent_nav_title = "edX Policy Change"
+    # link text displayed in banner box
     urgent_link_title = "Urgent: edX Policy Change"
     urgent_date = "2018-12-13"
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,7 +21,9 @@
                 <img src="{{ "img/jolly-roger.png" | relURL }}">
             </a>
             <a class="navbar-item" href="{{ .Site.BaseURL | relURL }}">Home</a>
-            <a class="navbar-item" href="{{ "/edx" | relURL }}">edX Update</a>
+            {{ if and (.Site.Params.display_urgent | default false) (isset .Site.Params "urgent_nav_title") }}
+            <a class="navbar-item" href="{{ .Site.Params.urgent_url}}">{{ .Site.Params.urgent_nav_title }}</a>
+            {{end}}
         
             <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
                 <span aria-hidden="true"></span>
@@ -37,8 +39,8 @@
             <div class="navbar-end">
                 <a class="navbar-item" href="{{ "/resources" | relURL }}">Resources</a>
                 <a class="navbar-item" href="{{ "/post" | relURL }}">Posts</a>
-                <a class="navbar-item" href="{{ .Site.Params.meetup_url }}">Meetup</a>
                 <a class="navbar-item" href="{{ "/about" | relURL }}">About</a>
+                <a class="navbar-item" href="{{ .Site.Params.meetup_url }}">Meetup</a>
             </div>
         </div>
     </nav>

--- a/layouts/partials/urgent-banner.html
+++ b/layouts/partials/urgent-banner.html
@@ -6,10 +6,10 @@
                     <article class="media">
                         <div class="media-content">
                             <div class="content">
-                                <p class="title is-4"><a href="{{ .Site.Params.urgent_link}}">{{ .Site.Params.urgent_link_title }}</a></p>
+                                <p class="title is-4"><a href="{{ .Site.Params.urgent_url}}">{{ .Site.Params.urgent_link_title }}</a></p>
                                 <p>edX is changing features available to students auditing classes!<br/>
                                 <em>You must sign up for all courses by end of this Sunday, Dec. 16 to have access to Problem Sets.</em></p>
-                                <p><a href="{{ .Site.Params.urgent_link}}">Additional details and links here.</a></p>
+                                <p><a href="{{ .Site.Params.urgent_url}}">Additional details and links here.</a></p>
                             </div>
                         </div>
                     </article>


### PR DESCRIPTION
- all "urgent" content is now configurable in the config.toml
- swapped positions of "About" and "Meetup" to push meetup outbound
  link to edge of page